### PR TITLE
Remove static positioning of chart

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PUBLIC_TEMPLE_URL="http://localhost:8000/api/"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PUBLIC_TEMPLE_URL="http://localhost:8000/api/"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 node_modules
 .svelte-kit
 build
+
+.env

--- a/src/lib/temple.ts
+++ b/src/lib/temple.ts
@@ -45,19 +45,19 @@ export async function get_solution_detail(
     )
 
     if (!solution_detail_request.ok) {
-        alert("Could not fetch " + url)
-        return {}
+        alert("Could not fetch " + url);
+        throw new Error("Could not fetch " + url);
     }
     let solution_detail = await solution_detail_request.json()
 
-    return solution_detail
+    return solution_detail;
 }
 
 /**
  * Helper function to fetch the unit endpoint of the temple. 
  * @param solution_name Name of the solution
  * @param component_name Name of the component
- * @param scenario_name Name of the scneario
+ * @param scenario_name Name of the scenario
  * @returns Papaparsed CSV of the Unit-Dataframe from the API Server
  */
 export async function get_unit(solution_name: string,
@@ -91,14 +91,11 @@ export async function get_energy_balance(
 ): Promise<EnergyBalanceDataframes> {
     const url = env.PUBLIC_TEMPLE_URL + `solutions/get_energy_balance/${solution}/${node}/${carrier}?scenario=${scenario}&year=${year}&rolling_average_size=${window_size}`
 
-    let energy_balance_data_request = await fetch(
-        url,
-        { cache: "no-store" }
-    );
+  let energy_balance_data_request = await fetch(url, { cache: "no-store" });
 
     if (!energy_balance_data_request.ok) {
-        alert("Could not fetch " + url)
-        return {}
+        alert("Could not fetch " + url);
+        throw new Error("Could not fetch " + url);
     }
 
     let energy_balance_data = await energy_balance_data_request.json()
@@ -134,7 +131,7 @@ export async function get_energy_balance(
  * Helper function that parses the CSV data as returned by the API. 
  * It parses the CSV using Papaparse but first normalizes the CSV string returned by the API: 
  * If the dataset only consists of one column, we transpose it s.t. the header consists of the years and it only has one more line containing the data. 
- * This is done because ZEN Garden sometimes returns a pd.Series and sometimes a pd.Dataframe. In case a pd.Datafram only consists of one column it is reformated to a Series-CSV Format.
+ * This is done because ZEN Garden sometimes returns a pd.Series and sometimes a pd.Dataframe. In case a pd.Dataframe only consists of one column it is reformated to a Series-CSV Format.
  * Furthermore the function transforms the years: In the CSV data from the API it is 0 based normally indexed and this function translates it to actual years.
  * @param data_csv CSV string
  * @param start_year Start year (corresponds to the 0-index)
@@ -209,11 +206,8 @@ export async function get_component_total(
     let component_data_request = await fetch(fetch_url, { cache: "no-store" });
 
     if (!component_data_request.ok) {
-        alert("Error when fetching " + fetch_url)
-        return {
-            unit: [],
-            data: []
-        }
+        alert("Error when fetching " + fetch_url);
+        throw new Error("Error when fetching " + fetch_url);
     }
 
     let component_data = await component_data_request.json();
@@ -264,18 +258,15 @@ export async function get_full_ts(
     component_name: string,
     scenario_name: string,
     year: number = 0,
-    window_size: number = 1) {
+    window_size: number = 1): Promise<ComponentTotal> {
 
     const fetch_url = env.PUBLIC_TEMPLE_URL + `solutions/get_full_ts/${solution_name}/${component_name}?scenario=${scenario_name}&year=${year}&rolling_average_size=${window_size}`
 
     let component_data_request = await fetch(fetch_url, { cache: "no-store" });
 
     if (!component_data_request.ok) {
-        alert("Error when fetching " + fetch_url)
-        return {
-            unit: [],
-            data: []
-        }
+        alert("Error when fetching " + fetch_url);
+        throw new Error("Error when fetching " + fetch_url);
     }
 
     let component_data = await component_data_request.json();

--- a/src/routes/energy_balance/nodal/+page.svelte
+++ b/src/routes/energy_balance/nodal/+page.svelte
@@ -350,7 +350,7 @@
 </div>
 <div class="row">
     <div class="col position-relative">
-        <div class="filters" style="position: absolute; width: 100%;">
+        <div class="filters">
             <div class="accordion" id="accordionExample">
                 <div class="accordion-item solution-selection">
                     <h2 class="accordion-header">
@@ -460,7 +460,7 @@
     </div>
 </div>
 <div class="row">
-    <div class="col" style="margin-top: 400px;">
+    <div class="col">
         {#if fetching}
             <div class="text-center">
                 <div class="spinner-border center" role="status">

--- a/src/routes/energy_balance/nodal/+page.svelte
+++ b/src/routes/energy_balance/nodal/+page.svelte
@@ -460,7 +460,7 @@
     </div>
 </div>
 <div class="row">
-    <div class="col">
+    <div class="col mt-4">
         {#if fetching}
             <div class="text-center">
                 <div class="spinner-border center" role="status">

--- a/src/routes/energy_balance/storage/+page.svelte
+++ b/src/routes/energy_balance/storage/+page.svelte
@@ -40,7 +40,7 @@
     let plot_config = {
         counter: 1,
         type: "line",
-        data: { datasets: [] as any[] },
+        data: { datasets: [] as any[], labels: [] as string[] },
         options: {
             animation: false,
             normalized: true,
@@ -451,7 +451,7 @@
     </div>
 </div>
 <div class="col">
-    <div class="row">
+    <div class="row mt-4">
         {#if solution_loading || fetching}
             <div class="text-center">
                 <div class="spinner-border center" role="status">

--- a/src/routes/energy_balance/storage/+page.svelte
+++ b/src/routes/energy_balance/storage/+page.svelte
@@ -323,7 +323,7 @@
 </div>
 <div class="row" style="z-index: 1; position: relative;">
     <div class="col position-relative">
-        <div class="filters" style="position: absolute; width: 100%;">
+        <div class="filters">
             <div class="accordion" id="accordionExample">
                 <div class="accordion-item solution-selection">
                     <h2 class="accordion-header">
@@ -450,7 +450,7 @@
         </div>
     </div>
 </div>
-<div class="col" style="margin-top: 400px;">
+<div class="col">
     <div class="row">
         {#if solution_loading || fetching}
             <div class="text-center">

--- a/src/routes/transition/capacity/+page.svelte
+++ b/src/routes/transition/capacity/+page.svelte
@@ -68,17 +68,16 @@
 	 * This function sets all the necessary variables back to the initial state in order to reset the plot.
 	 *
 	 */
-	async function reset_data_selection() {
+	function reset_data_selection() {
 		selected_normalisation = "not_normalized";
 		selected_locations = locations;
 		selected_technologies = technologies;
 		selected_years = years;
 		selected_aggregation = "node";
-		await tick();
 	}
 
 	/**
-	 * This function fetches the the data from the api of the selected values in the form
+	 * This function fetches the data from the api of the selected values in the form
 	 */
 	async function fetch_data() {
 		fetching = true;
@@ -157,7 +156,7 @@
 		let all_technologies: string[] = get_technologies_by_type();
 
 		// Add all the available carriers to the set of carriers for the current set of technologies
-		data!.data.forEach((element) => {
+		data.data.forEach((element) => {
 			let current_technology = element.technology;
 			let current_carrier =
 				selected_solution!.detail.reference_carrier[current_technology];

--- a/src/routes/transition/capacity/+page.svelte
+++ b/src/routes/transition/capacity/+page.svelte
@@ -344,7 +344,7 @@
 </div>
 <div class="row" style="z-index: 1; position: relative;">
 	<div class="col position-relative">
-		<div class="filters" style="position: absolute; width: 100%;">
+		<div class="filters">
 			<div class="accordion" id="accordionExample">
 				<div class="accordion-item solution-selection">
 					<h2 class="accordion-header">
@@ -538,7 +538,7 @@
 		</div>
 	</div>
 </div>
-<div class="col" style="margin-top: 400px;">
+<div class="col mt-4">
 	<div class="row">
 		{#if solution_loading || fetching}
 			<div class="text-center">

--- a/src/routes/transition/costs/+page.svelte
+++ b/src/routes/transition/costs/+page.svelte
@@ -517,7 +517,7 @@
 
 <div class="row">
 	<div class="col position-relative" style="z-index: 1; position: relative;">
-		<div class="filters" style="position: absolute; width: 100%;">
+		<div class="filters">
 			<div class="accordion" id="accordionExample">
 				<div class="accordion-item solution-selection">
 					<h2 class="accordion-header">
@@ -726,7 +726,7 @@
 	</div>
 </div>
 <div class="row">
-	<div class="col" style="margin-top: 400px;">
+	<div class="col">
 		{#if solution_loading || fetching}
 			<div class="text-center">
 				<div class="spinner-border center" role="status">

--- a/src/routes/transition/costs/+page.svelte
+++ b/src/routes/transition/costs/+page.svelte
@@ -726,7 +726,7 @@
 	</div>
 </div>
 <div class="row">
-	<div class="col">
+	<div class="col mt-4">
 		{#if solution_loading || fetching}
 			<div class="text-center">
 				<div class="spinner-border center" role="status">

--- a/src/routes/transition/emissions/+page.svelte
+++ b/src/routes/transition/emissions/+page.svelte
@@ -537,7 +537,7 @@
 	</div>
 </div>
 <div class="row">
-	<div class="col">
+	<div class="col mt-4">
 		{#if solution_loading || fetching}
 			<div class="text-center">
 				<div class="spinner-border center" role="status">

--- a/src/routes/transition/emissions/+page.svelte
+++ b/src/routes/transition/emissions/+page.svelte
@@ -352,7 +352,7 @@
 
 <div class="row">
 	<div class="col position-relative" style="z-index: 1; position: relative;">
-		<div class="filters" style="position: absolute; width: 100%;">
+		<div class="filters">
 			<div class="accordion" id="accordionExample">
 				<div class="accordion-item solution-selection">
 					<h2 class="accordion-header">
@@ -537,7 +537,7 @@
 	</div>
 </div>
 <div class="row">
-	<div class="col" style="margin-top: 400px;">
+	<div class="col">
 		{#if solution_loading || fetching}
 			<div class="text-center">
 				<div class="spinner-border center" role="status">

--- a/src/routes/transition/production/+page.svelte
+++ b/src/routes/transition/production/+page.svelte
@@ -421,7 +421,7 @@
 </div>
 <div class="row">
 	<div class="col position-relative" style="z-index: 1; position: relative;">
-		<div class="filters" style="position: absolute; width: 100%;">
+		<div class="filters">
 			<div class="accordion" id="accordionExample">
 				<div class="accordion-item solution-selection">
 					<h2 class="accordion-header">
@@ -617,7 +617,7 @@
 	</div>
 </div>
 <div class="row">
-	<div class="col" style="margin-top: 400px;">
+	<div class="col mt-4">
 		{#if solution_loading || fetching}
 			<div class="text-center">
 				<div class="spinner-border center" role="status">


### PR DESCRIPTION
I noticed that the chart sometimes is overlapped by the filters. This was because the filters were positioned `absolute` and the chart itself was pushed downwards using a large `margin-top` value. I changed this such that the chart is always below the filters dynamically.

Furthermore, I created a copy of `.env` that can safely be tracked with Git.